### PR TITLE
synchronized call to mutating ackHandlers.executeAck

### DIFF
--- a/Source/SocketIOClient.swift
+++ b/Source/SocketIOClient.swift
@@ -286,7 +286,9 @@ public final class SocketIOClient : NSObject, SocketEngineClient, SocketParsable
 
         DefaultSocketLogger.Logger.log("Handling ack: %@ with data: %@", type: logType, args: ack, data)
 
-        handleQueue.async() {
+        // No need to executeAck async because it is async internally, but dangerous because it's mutating
+        
+        handleQueue.sync() {
             self.ackHandlers.executeAck(ack, with: data, onQueue: self.handleQueue)
         }
     }


### PR DESCRIPTION
There's no need to executeAck async because it is async internally, but dangerous because it's mutating

Helps with memory issues when doing a hundred emits in a second. References socketio/socket.io-client-swift/issues/89
